### PR TITLE
Refactoring for numpy doc styles and typos. Address 3.4 build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ python:
 install:
   - pip install -r requirements/test.txt
 # command to run tests
-script: py.test --cov=./flask_minify tests/*
+script: flake8 ./flask_minify/* && py.test --cov=./flask_minify tests/*
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 <h1 align='center'> flask_minify </h1>
 <p align='center'>
-<a href='https://travis-ci.com/mrf345/flask_minify'><img src='https://travis-ci.com/mrf345/flask_minify.svg?branch=master'></a><a href='https://coveralls.io/github/mrf345/flask_minify?branch=master'><img src='https://coveralls.io/repos/github/mrf345/flask_minify/badge.svg?branch=master' alt='Coverage Status' /></a><img src='https://img.shields.io/github/v/tag/mrf345/flask_minify' alt='Latest Release' /><img src='https://img.shields.io/pypi/pyversions/flask_minify' alt='Supported versions' /><img src='https://img.shields.io/pypi/dm/flask_minify' alt='Number of downloads' />
+<a href='https://travis-ci.com/mrf345/flask_minify'>
+  <img src='https://travis-ci.com/mrf345/flask_minify.svg?branch=master'>
+</a>
+<img src='https://img.shields.io/github/v/tag/mrf345/flask_minify' alt='Latest Release' />
+<br />
+<img src='https://img.shields.io/pypi/pyversions/flask_minify' alt='Supported versions' />
+<br />
+<a href='https://coveralls.io/github/mrf345/flask_minify?branch=master'>
+  <img src='https://coveralls.io/repos/github/mrf345/flask_minify/badge.svg?branch=master' alt='Coverage Status' />
+</a>
+<img src='https://img.shields.io/badge/code%20style-pep8-orange.svg' alt='Code Style' />
+<img src='https://img.shields.io/pypi/dm/flask_minify' alt='Number of downloads' />
 </p>
 <h3 align='center'>A Flask extension to minify flask response for html, javascript, css and less compilation as well.</h3>
 
@@ -57,19 +68,24 @@ def __init__(
         self, app=None, html=True, js=True, cssless=True,
         fail_safe=True, bypass=[], bypass_caching=[], caching_limit=1
     ):
-        ''' Flask extension to minify flask response for html, javascript,
-            css and less.
+        ''' Extension to minify flask response for html, javascript, css and less.
 
-        Parameters:
+        Parameters
         ----------
-            app: Flask app instance to be passed.
-            js: To minify the css output.
-            cssless: To minify spaces in css.
-            cache: To cache minifed response with hash.
-            fail_safe: to avoid raising error while minifying.
-            bypass: list of endpoints to bypass minifying for. (Regex)
-            bypass_caching: list of endpoints to bypass caching for. (Regex)
-            caching_limit: to limit the number of minifed response variations.
+            app: Flask.app
+                Flask app instance to be passed.
+            js: bool
+                To minify the css output.
+            cssless: bool
+                To minify spaces in css.
+            fail_safe: bool
+                to avoid raising error while minifying.
+            bypass: list
+                list of endpoints to bypass minifying for. (Regex)
+            bypass_caching: list
+                list of endpoints to bypass caching for. (Regex)
+            caching_limit: int
+                to limit the number of minified response variations.
 
             NOTE: if `caching_limit` is set to 0, we'll not cache any endpoint
                   response, so if you want to disable caching just do that.
@@ -78,7 +94,7 @@ def __init__(
                     `@app.route()` so in the following example the endpoint
                     will be `root`:
 
-                     @app.('/root/<id>')
+                     @app.route('/root/<id>')
                      def root(id):
                          return id
 

--- a/flask_minify/__init__.py
+++ b/flask_minify/__init__.py
@@ -1,2 +1,4 @@
-# flake8: noqa
-from .main import minify
+from .main import minify # noqa
+
+__version__ = '0.17'
+__doc__ = 'Flask extension to minify html, css, js and less.'

--- a/flask_minify/utils.py
+++ b/flask_minify/utils.py
@@ -1,0 +1,16 @@
+from re import sub
+
+
+def is_empty(content):
+    ''' check if the content is truly empty.
+
+    Paramaters
+    ----------
+        content: str
+            content to check if it's truly empty.
+
+    Returns
+    -------
+        Boolean True if empty False if not.
+    '''
+    return not bool(len(sub(r'[ |\n|\t]', '', content or '').strip()))

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -3,3 +3,4 @@ lesscpy
 htmlmin
 jsmin
 xxhash
+pyyaml==5.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ pytest-cov
 coverage
 python-coveralls
 mock
+flake8

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,25 @@
-"""
-Flask-Minify
--------------
-
-A Flask extension to minify flask response for html,
-javascript, css and less compilation as well.
-
-"""
 from setuptools import setup
 from os import path
 
-# read the contents of your README file
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+from flask_minify import __version__ as VERSION
+from flask_minify import __doc__ as DOC
+
+
+with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'),
+          encoding='utf-8') as f:
     long_description = f.read()
 
 
 setup(
     name='Flask-Minify',
-    version='0.16',
+    version=VERSION,
     url='https://github.com/mrf345/flask_minify/',
-    download_url='https://github.com/mrf345/flask_minify/archive/0.13.tar.gz',
+    download_url='https://github.com/mrf345/flask_minify/archive/%s.tar.gz'
+    % VERSION,
     license='MIT',
     author='Mohamed Feddad',
     author_email='mrf345@gmail.com',
-    description='flask extension to minify html, css, js and less',
+    description=DOC,
     long_description=long_description,
     long_description_content_type='text/markdown',
     py_modules=['minify'],

--- a/tests/units.py
+++ b/tests/units.py
@@ -2,6 +2,8 @@ from sys import path as sys_path
 from os import path
 from importlib import import_module
 
+from flask_minify.utils import (is_empty)
+
 
 sys_path.append(path.dirname(path.dirname(__file__)))
 minify = import_module('flask_minify').minify
@@ -9,6 +11,14 @@ unittest = import_module('unittest')
 
 # workaround for py2 vs py3 mock import
 mock = getattr(unittest, 'mock', None) or import_module('mock')
+
+
+class TestUtils:
+    def test_is_empty(self):
+        ''' Test is_empty check is correct '''
+
+        assert is_empty('Not empty at all') is False
+        assert is_empty('\n\t  \t\n\n' * 10) is True
 
 
 class TestMinifyRequest:


### PR DESCRIPTION
- Lock `pyyaml` requirements version to fix `python 3.4` build failure
- Refactor doc style to numpy
- Refactor inline regex `is_empty` check
- Add unittest for `is_empty` check
- Add flake8 check to `.trvais` and badge to `README`
- Move `__version__` and `__doc__` to `__init__.py`