### PR TITLE
Minor refactoring, fixes and bump 0.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ def example():
 ```python
 def __init__(
         self, app=None, html=True, js=True, cssless=True,
-        fail_safe=True, bypass=[], bypass_caching=[], caching_limit=1,
-        passive=False, static=False
+        fail_safe=True, bypass=[], bypass_caching=[], caching_limit=2,
+        passive=False, static=True
     ):
         ''' Extension to minify flask response for html, javascript, css and less.
 

--- a/flask_minify/__init__.py
+++ b/flask_minify/__init__.py
@@ -1,3 +1,3 @@
-from .main import minify # noqa
+from .main import Minify as minify # noqa
 from . import decorators # noqa
 from .about import (__license__, __version__, __author__, __doc__, __email__) # noqa

--- a/flask_minify/about.py
+++ b/flask_minify/about.py
@@ -1,4 +1,4 @@
-__version__ = '0.21'
+__version__ = '0.22'
 __doc__ = 'Flask extension to minify html, css, js and less.'
 __license__ = 'MIT'
 __author__ = 'Mohamed Feddad'

--- a/flask_minify/decorators.py
+++ b/flask_minify/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from .main import hashing, minify as main
+from .main import hashing, Minify as main
 from .utils import get_tag_contents
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -59,24 +59,3 @@ MINIFIED_LESS_RAW = b'body{color:red;}'
 
 MINIFIED_JS_TEMPLATE_LITERALS =\
     "const a='something';const b=` more  than    ${a}  `"
-
-
-def MINIFED_STRIPED(value):
-    constant = globals().get(value, '')
-
-    if type(constant) == bytes:
-        constant = bytes(constant.decode('utf-8')
-                                 .replace('<style>', '')
-                                 .replace('</style>', '')
-                                 .replace('<script>', '')
-                                 .replace('</script>', '')
-                                 .encode('utf-8'))
-    else:
-        constant = str(constant.encode('utf-8')
-                               .replace('<style>', '')
-                               .replace('</style>', '')
-                               .replace('<script>', '')
-                               .replace('</script>', '')
-                               .decode('utf-8'))
-
-    return constant


### PR DESCRIPTION
- Refactor doc strings spacing to be consistent
- Fix `self.static` been ignored
- Fix inline style and script cached separately
- Enable static files minifying by default
- Increase cache limit to 2
- Bump version to 0.22
- Capitalize class name