### PR TITLE
Fix tag matching regex

### DIFF
--- a/flask_minify/utils.py
+++ b/flask_minify/utils.py
@@ -71,7 +71,7 @@ def get_tag_contents(html, tag, script_types):
     -------
         String of specific tag's inner content.
     '''
-    contents = compile_re(r'(<{0}[^>]*>)(.+?)</{0}>'
+    contents = compile_re(r'(<{0}[^>]*>)(.*?)</{0}>'
                           .format(tag), DOTALL).findall(html)
 
     return [content[1] for content in contents


### PR DESCRIPTION
Fix to allow for matching empty tags.
e.g.:
This input: `<script src="xxx"></script><script src="yyy"></script><script src="zzz"></script>`
was only matching tag: `<script src="xxx">` with content: `</script><script src="yyy">`
instead of matching all 3 tags: `<script src="xxx">`, `<script src="yyy">` and `<script src="zzz">`, all with empty content.