### PR TITLE
Update repository to use 🐍 `3.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: Build
 on:
-  pull_request:
-    branches: [ main ]
   push:
   schedule:
     # runs a new build everyday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Build
 on:
+  pull_request:
+    branches: [ main ]
   push:
   schedule:
     # runs a new build everyday

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install dependencies
         run: pip install -r requirements/test.txt
       - name: Set coverage percentage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE files
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE files
 .idea
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/flask_minify/about.py
+++ b/flask_minify/about.py
@@ -1,4 +1,4 @@
-__version__ = "0.42"
+__version__ = "0.43"
 __doc__ = "Flask extension to minify html, css, js and less."
 __license__ = "MIT"
 __author__ = "Mohamed Feddad"


### PR DESCRIPTION
## What is this doing?
Changes the coverage Action to use v`3.11`, adds v`3.11` to the list of CI versions, removes v`3.6` from the list of CI versions, and changes the version of Ubuntu being used to the latest version.